### PR TITLE
Add docker-compose and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# API keys
+OPENROUTER_API_KEY=
+SUPERMEMORY_API_KEY=
+SUPERMEMORY_BASE_URL=https://api.supermemory.ai/v3
+OPENAI_API_KEY=
+
+# Neo4j configuration
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=
+NEO4J_URI=bolt://neo4j:7687
+
+# Redis configuration
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# Weaviate configuration
+WEAVIATE_HOST=weaviate
+WEAVIATE_PORT=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,67 @@
+version: '3.8'
+
+services:
+  weaviate:
+    image: semitechnologies/weaviate:1.24.10
+    restart: on-failure
+    ports:
+      - "8080:8080"
+    environment:
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
+      DEFAULT_VECTORIZER_MODULE: text2vec-openai
+      ENABLE_MODULES: text2vec-openai
+      OPENAI_APIKEY: ${OPENAI_API_KEY}
+      CLUSTER_HOSTNAME: node1
+      PERSISTENCE_DATA_PATH: /var/lib/weaviate
+    volumes:
+      - weaviate_data:/var/lib/weaviate
+    networks:
+      - app-network
+
+  neo4j:
+    image: neo4j:5
+    restart: on-failure
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    environment:
+      NEO4J_AUTH: "${NEO4J_USER}/${NEO4J_PASSWORD}"
+    volumes:
+      - neo4j_data:/data
+    networks:
+      - app-network
+
+  redis:
+    image: redis:7-alpine
+    restart: on-failure
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - app-network
+
+  app:
+    image: python:3.11-slim
+    command: tail -f /dev/null
+    volumes:
+      - .:/app
+    working_dir: /app
+    env_file:
+      - .env
+    depends_on:
+      - weaviate
+      - neo4j
+      - redis
+    networks:
+      - app-network
+
+volumes:
+  weaviate_data:
+  neo4j_data:
+  redis_data:
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- set up `docker-compose.yml` with Weaviate + text2vec-openai, Neo4j 5.x, Redis and Python app container
- provide `.env.example` showing required environment variables

## Testing
- `node test-runner.js list`
- `node test-runner.js integration` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6856bbc1709c83228bb78d56da373ba2