### PR TITLE
Implement temporal extraction components

### DIFF
--- a/docs/temporal-meeting-intelligence-v3.md
+++ b/docs/temporal-meeting-intelligence-v3.md
@@ -1,0 +1,10 @@
+# Temporal Meeting Intelligence System - Complete Requirements & Implementation Guide v3.0
+
+This document outlines the architecture and implementation guidance for the Temporal Meeting Intelligence system. It supersedes previous requirement versions and introduces temporal awareness, dual storage in Weaviate and Neo4j, and an advanced extraction pipeline.
+
+For brevity the full text from the design discussion is not reproduced here. See the project discussion for the detailed plan. Key components implemented in this repository include:
+
+- `TemporalMemoryChunk` dataclass describing temporally aware memory slices
+- `TemporalExtractor` for turning transcripts into `TemporalMemoryChunk` objects
+- `DualStorageManager` handling persistence to Weaviate and Neo4j
+- An updated `WEAVIATE_SCHEMA` defining both `MemoryChunk` and `Meeting` classes

--- a/meeting-intelligence/src/__init__.py
+++ b/meeting-intelligence/src/__init__.py
@@ -1,0 +1,5 @@
+"""Meeting Intelligence package."""
+
+from .models.temporal_memory import TemporalMemoryChunk
+from .extraction.temporal_extractor import TemporalExtractor
+from .storage.dual_storage_manager import DualStorageManager

--- a/meeting-intelligence/src/extraction/temporal_extractor.py
+++ b/meeting-intelligence/src/extraction/temporal_extractor.py
@@ -1,0 +1,124 @@
+"""Temporal extraction utilities."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from typing import List, Dict, Optional, Any
+
+from openai import OpenAI
+
+from ..models.temporal_memory import TemporalMemoryChunk
+
+
+class TemporalExtractor:
+    """Extract temporally aware memory chunks from transcripts."""
+
+    def __init__(self) -> None:
+        self.client = OpenAI()
+        self.extraction_prompt = """
+You are analyzing a meeting transcript to extract temporal memory chunks.
+
+Meeting Context:
+{meeting_context}
+
+Previous Meeting Topics (for temporal linking):
+{historical_topics}
+
+Transcript Section:
+{transcript_section}
+
+Return output as JSON with a `chunks` list.
+"""
+
+    def extract_temporal_chunks(
+        self,
+        transcript: str,
+        meeting_metadata: Dict[str, Any],
+        historical_context: List[Dict[str, Any]],
+    ) -> List[TemporalMemoryChunk]:
+        """Extract temporal chunks from a transcript."""
+
+        sections = self._segment_transcript(transcript)
+        all_chunks: List[TemporalMemoryChunk] = []
+        for section in sections:
+            chunks = self._extract_section_chunks(
+                section, meeting_metadata, historical_context
+            )
+            all_chunks.extend(chunks)
+        return all_chunks
+
+    def _segment_transcript(self, transcript: str) -> List[str]:
+        """Segment transcript using speaker labels as hints."""
+        pattern = r"([A-Z][a-z]+):\s*(.+?)(?=\n[A-Z][a-z]+:|$)"
+        matches = re.findall(pattern, transcript, re.DOTALL)
+        if not matches:
+            return [p.strip() for p in transcript.split("\n\n") if p.strip()]
+        sections = []
+        current = ""
+        for idx, (speaker, content) in enumerate(matches):
+            current += f"{speaker}: {content.strip()}\n"
+            if idx < len(matches) - 1 and content.strip().endswith("."):
+                sections.append(current.strip())
+                current = ""
+        if current:
+            sections.append(current.strip())
+        return sections
+
+    def _extract_section_chunks(
+        self,
+        section: str,
+        meeting_metadata: Dict[str, Any],
+        historical_context: List[Dict[str, Any]],
+    ) -> List[TemporalMemoryChunk]:
+        """Call the LLM to extract chunks for a section."""
+        historical_topics = [
+            f"{ctx.get('meeting_date')}: {', '.join(ctx.get('topics', []))}"
+            for ctx in historical_context[-5:]
+        ]
+        response = self.client.chat.completions.create(
+            model="gpt-4-turbo-preview",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You extract temporal memory chunks from meeting transcripts.",
+                },
+                {
+                    "role": "user",
+                    "content": self.extraction_prompt.format(
+                        meeting_context=json.dumps(meeting_metadata, indent=2),
+                        historical_topics="\n".join(historical_topics),
+                        transcript_section=section,
+                    ),
+                },
+            ],
+            temperature=0.1,
+            response_format={"type": "json_object"},
+        )
+        try:
+            data = json.loads(response.choices[0].message.content)
+        except Exception:
+            return []
+        chunks = []
+        for idx, chunk_data in enumerate(data.get("chunks", [])):
+            chunk = TemporalMemoryChunk(
+                chunk_id=f"{meeting_metadata['meeting_id']}_chunk_{idx}",
+                meeting_id=meeting_metadata["meeting_id"],
+                timestamp=meeting_metadata["date"],
+                speaker=chunk_data.get("speaker", ""),
+                addressed_to=chunk_data.get("addressed_to", []),
+                interaction_type=chunk_data.get("interaction_type", "discussion"),
+                content=chunk_data.get("content", ""),
+                full_context=chunk_data.get("full_context", ""),
+                structured_data=chunk_data.get("structured_data"),
+                temporal_markers=chunk_data.get("temporal_markers", []),
+                topics_discussed=chunk_data.get("topics_discussed", []),
+                entities_mentioned=chunk_data.get("entities_mentioned", []),
+                version_info=chunk_data.get("version_info"),
+                importance_score=chunk_data.get("importance_score", 5.0),
+                references_past=chunk_data.get("references_past", []),
+                creates_future=chunk_data.get("creates_future", []),
+            )
+            chunks.append(chunk)
+        return chunks

--- a/meeting-intelligence/src/models/temporal_memory.py
+++ b/meeting-intelligence/src/models/temporal_memory.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Dict, Optional, Any
+
+
+@dataclass
+class TemporalMemoryChunk:
+    """Rich memory chunk with temporal awareness."""
+
+    chunk_id: str
+    meeting_id: str
+    timestamp: datetime
+    speaker: str
+    addressed_to: List[str] = field(default_factory=list)
+    interaction_type: str = "discussion"
+    content: str = ""
+    full_context: str = ""
+    structured_data: Optional[Dict[str, Any]] = None
+    temporal_markers: List[str] = field(default_factory=list)
+    topics_discussed: List[str] = field(default_factory=list)
+    entities_mentioned: List[str] = field(default_factory=list)
+    version_info: Optional[Dict[str, str]] = None
+    importance_score: float = 5.0
+    references_past: List[Dict[str, Any]] = field(default_factory=list)
+    creates_future: List[Dict[str, Any]] = field(default_factory=list)

--- a/meeting-intelligence/src/models/weaviate_schemas.py
+++ b/meeting-intelligence/src/models/weaviate_schemas.py
@@ -1,28 +1,132 @@
 from __future__ import annotations
 
-from typing import Dict, Any
+from typing import Dict, Any, List
+
+# Full Weaviate schema for the Temporal Meeting Intelligence system
+WEAVIATE_SCHEMA: Dict[str, Any] = {
+    "classes": [
+        {
+            "class": "MemoryChunk",
+            "description": "Atomic unit of meeting memory with temporal awareness",
+            "vectorizer": "text2vec-openai",
+            "moduleConfig": {
+                "text2vec-openai": {
+                    "model": "text-embedding-3-small",
+                    "type": "text",
+                    "options": {"waitForModel": True, "useGPU": True},
+                }
+            },
+            "properties": [
+                {"name": "chunkId", "dataType": ["string"], "indexInverted": True},
+                {
+                    "name": "meetingId",
+                    "dataType": ["string"],
+                    "indexInverted": True,
+                    "indexFilterable": True,
+                },
+                {
+                    "name": "timestamp",
+                    "dataType": ["date"],
+                    "indexInverted": True,
+                    "indexRangeFilters": True,
+                },
+                {
+                    "name": "speaker",
+                    "dataType": ["string"],
+                    "indexInverted": True,
+                    "indexFilterable": True,
+                },
+                {
+                    "name": "addressedTo",
+                    "dataType": ["string[]"],
+                    "indexInverted": True,
+                },
+                {
+                    "name": "interactionType",
+                    "dataType": ["string"],
+                    "indexInverted": True,
+                    "indexFilterable": True,
+                },
+                {
+                    "name": "content",
+                    "dataType": ["text"],
+                    "indexSearchable": True,
+                    "moduleConfig": {
+                        "text2vec-openai": {
+                            "skip": False,
+                            "vectorizePropertyName": False,
+                        }
+                    },
+                },
+                {"name": "fullContext", "dataType": ["text"]},
+                {"name": "structuredData", "dataType": ["object"]},
+                {
+                    "name": "temporalMarkers",
+                    "dataType": ["string[]"],
+                    "indexInverted": True,
+                },
+                {
+                    "name": "topicsDiscussed",
+                    "dataType": ["string[]"],
+                    "indexInverted": True,
+                },
+                {
+                    "name": "entitiesMentioned",
+                    "dataType": ["string[]"],
+                    "indexInverted": True,
+                },
+                {"name": "versionInfo", "dataType": ["object"]},
+                {
+                    "name": "importanceScore",
+                    "dataType": ["number"],
+                    "indexInverted": True,
+                    "indexRangeFilters": True,
+                },
+            ],
+            "invertedIndexConfig": {
+                "indexTimestamps": True,
+                "indexNullState": True,
+                "indexPropertyLength": True,
+            },
+        },
+        {
+            "class": "Meeting",
+            "description": "Meeting metadata and summary",
+            "properties": [
+                {"name": "meetingId", "dataType": ["string"], "indexInverted": True},
+                {"name": "title", "dataType": ["string"], "indexSearchable": True},
+                {
+                    "name": "date",
+                    "dataType": ["date"],
+                    "indexInverted": True,
+                    "indexRangeFilters": True,
+                },
+                {
+                    "name": "participants",
+                    "dataType": ["string[]"],
+                    "indexInverted": True,
+                },
+                {"name": "platform", "dataType": ["string"]},
+                {
+                    "name": "project",
+                    "dataType": ["string"],
+                    "indexInverted": True,
+                    "indexFilterable": True,
+                },
+                {"name": "meetingType", "dataType": ["string"], "indexInverted": True},
+                {"name": "transcriptUrl", "dataType": ["string"]},
+                {"name": "duration", "dataType": ["int"]},
+                {"name": "summary", "dataType": ["text"]},
+            ],
+        },
+    ]
+}
 
 
 def memory_object_schema() -> Dict[str, Any]:
-    """Return Weaviate schema for MemoryObject."""
-    return {
-        "class": "MemoryObject",
-        "properties": [
-            {"name": "meeting_id", "dataType": ["string"]},
-            {"name": "type", "dataType": ["string"]},
-            {"name": "content", "dataType": ["text"]},
-            {"name": "confidence", "dataType": ["number"]},
-        ],
-        "vectorizer": "text2vec-openai",
-    }
+    """Backward compatibility alias."""
+    return WEAVIATE_SCHEMA["classes"][0]
 
 
 def meeting_schema() -> Dict[str, Any]:
-    return {
-        "class": "Meeting",
-        "properties": [
-            {"name": "subject", "dataType": ["text"]},
-            {"name": "date", "dataType": ["date"]},
-        ],
-        "vectorizer": "text2vec-openai",
-    }
+    return WEAVIATE_SCHEMA["classes"][1]

--- a/meeting-intelligence/src/storage/dual_storage_manager.py
+++ b/meeting-intelligence/src/storage/dual_storage_manager.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+from typing import List, Dict, Any
+
+import weaviate
+from neo4j import GraphDatabase
+
+from ..models.temporal_memory import TemporalMemoryChunk
+
+
+class DualStorageManager:
+    """Store data in both Weaviate and Neo4j."""
+
+    def __init__(self, weaviate_url: str, neo4j_uri: str, neo4j_auth: tuple) -> None:
+        self.weaviate_client = weaviate.Client(
+            url=weaviate_url,
+            additional_headers={"X-OpenAI-Api-Key": os.getenv("OPENAI_API_KEY", "")},
+        )
+        self.neo4j_driver = GraphDatabase.driver(neo4j_uri, auth=neo4j_auth)
+
+    def close(self) -> None:
+        self.neo4j_driver.close()
+
+    def store_meeting(
+        self, meeting_metadata: Dict[str, Any], chunks: List[TemporalMemoryChunk]
+    ) -> bool:
+        """Store meeting data in both databases."""
+        try:
+            self._store_in_weaviate(meeting_metadata, chunks)
+            self._store_in_neo4j(meeting_metadata, chunks)
+            return True
+        except Exception as exc:  # pragma: no cover - simple sample
+            print(f"Storage error: {exc}")
+            return False
+
+    def _store_in_weaviate(
+        self, meeting_metadata: Dict[str, Any], chunks: List[TemporalMemoryChunk]
+    ) -> None:
+        meeting_object = {
+            "meetingId": meeting_metadata["meeting_id"],
+            "title": meeting_metadata["title"],
+            "date": meeting_metadata["date"].isoformat(),
+            "participants": meeting_metadata.get("participants", []),
+            "platform": meeting_metadata.get("platform", "unknown"),
+            "project": meeting_metadata.get("project", ""),
+            "meetingType": meeting_metadata.get("type", "discussion"),
+        }
+        self.weaviate_client.data_object.create(meeting_object, class_name="Meeting")
+        with self.weaviate_client.batch as batch:
+            for chunk in chunks:
+                batch.add_data_object(
+                    {
+                        "chunkId": chunk.chunk_id,
+                        "meetingId": chunk.meeting_id,
+                        "timestamp": chunk.timestamp.isoformat(),
+                        "speaker": chunk.speaker,
+                        "addressedTo": chunk.addressed_to,
+                        "interactionType": chunk.interaction_type,
+                        "content": chunk.content,
+                        "fullContext": chunk.full_context,
+                        "structuredData": chunk.structured_data,
+                        "temporalMarkers": chunk.temporal_markers,
+                        "topicsDiscussed": chunk.topics_discussed,
+                        "entitiesMentioned": chunk.entities_mentioned,
+                        "versionInfo": chunk.version_info,
+                        "importanceScore": chunk.importance_score,
+                    },
+                    class_name="MemoryChunk",
+                )
+
+    def _store_in_neo4j(
+        self, meeting_metadata: Dict[str, Any], chunks: List[TemporalMemoryChunk]
+    ) -> None:
+        with self.neo4j_driver.session() as session:
+            session.write_transaction(self._create_meeting_tx, meeting_metadata)
+            for chunk in chunks:
+                session.write_transaction(
+                    self._create_chunk_tx, chunk, meeting_metadata
+                )
+
+    @staticmethod
+    def _create_meeting_tx(tx, meeting_metadata: Dict[str, Any]) -> None:
+        query = (
+            "MERGE (m:Meeting {meetingId: $id}) "
+            "SET m.title=$title, m.date=datetime($date)"
+        )
+        tx.run(
+            query,
+            id=meeting_metadata["meeting_id"],
+            title=meeting_metadata["title"],
+            date=meeting_metadata["date"].isoformat(),
+        )
+
+    @staticmethod
+    def _create_chunk_tx(
+        tx, chunk: TemporalMemoryChunk, meeting_metadata: Dict[str, Any]
+    ) -> None:
+        query = (
+            "MERGE (c:Chunk {chunkId: $cid}) "
+            "SET c.content=$content, c.speaker=$speaker, c.timestamp=datetime($ts) "
+            "WITH c MATCH (m:Meeting {meetingId: $mid}) MERGE (c)-[:SPOKEN_IN]->(m)"
+        )
+        tx.run(
+            query,
+            cid=chunk.chunk_id,
+            content=chunk.content,
+            speaker=chunk.speaker,
+            ts=chunk.timestamp.isoformat(),
+            mid=meeting_metadata["meeting_id"],
+        )


### PR DESCRIPTION
## Summary
- add `TemporalMemoryChunk` dataclass describing temporal meeting segments
- implement `TemporalExtractor` for converting transcript sections into memory chunks
- add `DualStorageManager` stub for Weaviate and Neo4j persistence
- update Weaviate schemas with full `MemoryChunk` and `Meeting` definitions
- document new Temporal Meeting Intelligence design

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6856f472e5148322b4d007f1ffd6620e