### PR TITLE
Implement foundation data models and clients

### DIFF
--- a/meeting-intelligence/src/config/__init__.py
+++ b/meeting-intelligence/src/config/__init__.py
@@ -1,0 +1,1 @@
+from .settings import Settings

--- a/meeting-intelligence/src/config/settings.py
+++ b/meeting-intelligence/src/config/settings.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, Field
 
 
 class Settings(BaseSettings):
-    openai_apikey: str
-    neo4j_password: str
+    """Application configuration with environment overrides."""
+
+    openai_apikey: str = Field(..., env="OPENAI_API_KEY")
+    weaviate_url: str = Field("http://localhost:8080", env="WEAVIATE_URL")
+    neo4j_uri: str = Field("bolt://localhost:7687", env="NEO4J_URI")
+    neo4j_user: str = Field("neo4j", env="NEO4J_USER")
+    neo4j_password: str = Field(..., env="NEO4J_PASSWORD")
+    openai_model: str = Field("gpt-4-turbo-preview", env="OPENAI_MODEL")
+    max_memories: int = Field(15, env="MAX_MEMORIES")
+    request_timeout: int = Field(30, env="REQUEST_TIMEOUT")
+    feature_phase: str = Field("phase1", env="FEATURE_PHASE")
 
     class Config:
-        env_file = '.env'
+        env_file = ".env"
+        case_sensitive = False

--- a/meeting-intelligence/src/ingestion/__init__.py
+++ b/meeting-intelligence/src/ingestion/__init__.py
@@ -1,0 +1,1 @@
+from .email_parser import EmailParser, MeetingData\nfrom .memory_factory import MemoryFactory

--- a/meeting-intelligence/src/ingestion/email_parser.py
+++ b/meeting-intelligence/src/ingestion/email_parser.py
@@ -1,15 +1,52 @@
 from __future__ import annotations
 
+from email import policy
 from email.parser import BytesParser
-from email.policy import default
+from email.utils import parsedate_to_datetime, getaddresses
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
+
+from pydantic import BaseModel
+
+
+class MeetingData(BaseModel):
+    meeting_id: str
+    subject: str
+    date: Optional[str]
+    participants: List[str]
+    body: str
 
 
 class EmailParser:
-    """Parses .eml files and extracts basic metadata."""
+    """Parses .eml files and extracts meeting information."""
 
-    def parse(self, path: Path) -> Optional[str]:
-        with path.open('rb') as f:
-            msg = BytesParser(policy=default).parse(f)
-        return msg.get_body(preferencelist=('plain', 'html')).get_content()
+    def parse(self, path: Path) -> Optional[MeetingData]:
+        try:
+            with path.open("rb") as f:
+                msg = BytesParser(policy=policy.default).parse(f)
+        except Exception as exc:
+            raise RuntimeError(f"Failed to parse email: {exc}") from exc
+
+        body = msg.get_body(preferencelist=("plain", "html"))
+        content = body.get_content() if body else ""
+
+        addresses = getaddresses(msg.get_all("from", []) + msg.get_all("to", []) + msg.get_all("cc", []))
+        participants = [addr for name, addr in addresses]
+
+        date_hdr = msg.get("date")
+        parsed_date = None
+        if date_hdr:
+            try:
+                parsed_date = parsedate_to_datetime(date_hdr).isoformat()
+            except Exception:
+                parsed_date = None
+
+        meeting_id = msg.get("Message-ID", "")
+
+        return MeetingData(
+            meeting_id=meeting_id.strip("<>") if meeting_id else "",
+            subject=msg.get("subject", "").strip(),
+            date=parsed_date,
+            participants=participants,
+            body=content,
+        )

--- a/meeting-intelligence/src/ingestion/memory_factory.py
+++ b/meeting-intelligence/src/ingestion/memory_factory.py
@@ -1,14 +1,53 @@
 from __future__ import annotations
 
 from typing import List
+import json
 
-from ..models.memory_objects import MemoryObject, MemoryType
+from openai import OpenAI
+
+from ..models.memory_objects import MemoryObject
+
+EXTRACTION_PROMPT = (
+    "You are extracting structured memory objects from a meeting transcript. "
+    "Return 8-15 JSON objects in a field called 'memories' following this schema:\n"
+    "{schema}\nTranscript:\n{text}\n"
+)
 
 
 class MemoryFactory:
-    """Stub for future memory extraction logic."""
+    """LLM-backed memory extraction."""
+
+    def __init__(self, client: OpenAI | None = None) -> None:
+        self.client = client or OpenAI()
 
     def create_memories(self, text: str, meeting_id: str) -> List[MemoryObject]:
-        return [
-            MemoryObject(meeting_id=meeting_id, type=MemoryType.TOPIC, content=text, confidence=1.0)
-        ]
+        schema = {
+            "id": "string",
+            "customId": "string",
+            "type": "string",
+            "timestamp": "date",
+            "content": {"primary": "string"},
+        }
+
+        prompt = EXTRACTION_PROMPT.format(schema=schema, text=text)
+        response = self.client.chat.completions.create(
+            model="gpt-4-turbo-preview",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.1,
+            response_format={"type": "json_object"},
+        )
+
+        try:
+            data = json.loads(response.choices[0].message.content)
+            memories_data = data.get("memories", [])
+        except Exception:
+            memories_data = []
+
+        memories: List[MemoryObject] = []
+        for mem in memories_data:
+            try:
+                memories.append(MemoryObject(meeting_id=meeting_id, **mem))
+            except Exception:
+                continue
+
+        return memories

--- a/meeting-intelligence/src/models/__init__.py
+++ b/meeting-intelligence/src/models/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['MemoryObject', 'MemoryType', 'MemoryContent', 'MemoryEntities', 'TemporalInfo']

--- a/meeting-intelligence/src/models/memory_objects.py
+++ b/meeting-intelligence/src/models/memory_objects.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional, List
+from typing import Optional, List, Dict, Any
+from datetime import datetime
+from uuid import uuid4
+
 from pydantic import BaseModel, Field, validator
 
 
@@ -16,16 +19,45 @@ class MemoryType(str, Enum):
     TEMPORAL = "Temporal"
 
 
+class MemoryContent(BaseModel):
+    """Structured content extracted from the transcript."""
+
+    primary: str
+    context: Optional[str] = ""
+    raw: Optional[str] = ""
+
+    @validator("primary", "context", "raw", pre=True, always=True)
+    def strip_text(cls, value: Optional[str]) -> str:
+        return value.strip() if isinstance(value, str) else ""
+
+
+class MemoryEntities(BaseModel):
+    """Entities referenced in this memory object."""
+
+    people: List[str] = Field(default_factory=list)
+    artifacts: List[str] = Field(default_factory=list)
+    projects: List[str] = Field(default_factory=list)
+
+
+class TemporalInfo(BaseModel):
+    """Temporal references and dependencies."""
+
+    references: List[str] = Field(default_factory=list)
+    deadlines: List[datetime] = Field(default_factory=list)
+    dependencies: List[str] = Field(default_factory=list)
+
+
 class MemoryObject(BaseModel):
     """Represents a piece of information extracted from a meeting."""
 
-    id: Optional[str] = None
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    custom_id: Optional[str] = None
     meeting_id: str
     type: MemoryType
-    content: str
+    timestamp: datetime
+    content: MemoryContent
+    entities: MemoryEntities = Field(default_factory=MemoryEntities)
+    temporal: TemporalInfo = Field(default_factory=TemporalInfo)
     confidence: float = Field(..., ge=0.0, le=1.0)
+    metadata: Optional[Dict[str, Any]] = None
     related_to: Optional[List[str]] = None
-
-    @validator("content")
-    def strip_content(cls, value: str) -> str:
-        return value.strip()

--- a/meeting-intelligence/src/models/neo4j_models.py
+++ b/meeting-intelligence/src/models/neo4j_models.py
@@ -1,14 +1,70 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
+from typing import Dict, Any
 
 
 class Relation(str, Enum):
     PARTICIPATED_IN = "PARTICIPATED_IN"
     DECISION_OF = "DECISION_OF"
     ACTION_OF = "ACTION_OF"
+    DISCUSSED_IN = "DISCUSSED_IN"
+    PRECEDED = "PRECEDED"
+    WORKED_ON = "WORKED_ON"
 
 
-def create_meeting_node(meeting_id: str) -> str:
+@dataclass
+class Node:
+    label: str
+    key: str
+    properties: Dict[str, Any]
 
-    return f"MERGE (m:Meeting {{id: \"{meeting_id}\"}})"
+    def merge_cypher(self) -> str:
+        all_props = {self.key: self.properties.get(self.key)} | self.properties
+        props = ", ".join(f"{k}: ${k}" for k in all_props)
+        return f"MERGE (n:{self.label} {{{self.key}: ${self.key}}}) SET n += {{{props}}}"
+
+
+@dataclass
+class Meeting(Node):
+    label: str = "Meeting"
+    key: str = "meetingId"
+
+
+@dataclass
+class Person(Node):
+    label: str = "Person"
+    key: str = "email"
+
+
+@dataclass
+class Artifact(Node):
+    label: str = "Artifact"
+    key: str = "artifactId"
+
+
+@dataclass
+class Decision(Node):
+    label: str = "Decision"
+    key: str = "decisionId"
+
+
+@dataclass
+class ActionItem(Node):
+    label: str = "ActionItem"
+    key: str = "actionId"
+
+
+@dataclass
+class Topic(Node):
+    label: str = "Topic"
+    key: str = "topicId"
+
+
+def create_relationship_query(start_label: str, end_label: str, rel: Relation, properties: Dict[str, Any] | None = None) -> str:
+    props = ''
+    if properties:
+        props = ' {' + ', '.join(f"{k}: ${k}" for k in properties) + '}'
+    return f"MERGE (a:{start_label})-[r:{rel.value}{props}]->(b:{end_label})"
+

--- a/meeting-intelligence/src/models/weaviate_schemas.py
+++ b/meeting-intelligence/src/models/weaviate_schemas.py
@@ -1,28 +1,69 @@
 from __future__ import annotations
 
-from typing import Dict, Any
+from typing import Dict, Any, List
+
+_EMBEDDING_MODULE = {
+    "text2vec-openai": {
+        "model": "text-embedding-3-small",
+        "type": "text",
+        "options": {"waitForModel": True, "useGPU": True, "vectorizeClassName": False},
+    }
+}
 
 
 def memory_object_schema() -> Dict[str, Any]:
     """Return Weaviate schema for MemoryObject."""
+
+    properties: List[Dict[str, Any]] = [
+        {
+            "name": "content",
+            "dataType": ["text"],
+            "description": "Primary content of the memory",
+            "moduleConfig": {"text2vec-openai": {"skip": False, "vectorizePropertyName": False}},
+        },
+        {
+            "name": "contextualContent",
+            "dataType": ["text"],
+            "description": "Full context including surrounding discussion",
+        },
+        {"name": "meetingId", "dataType": ["string"], "indexInverted": True, "indexFilterable": True},
+        {"name": "memoryType", "dataType": ["string"], "indexInverted": True, "indexFilterable": True},
+        {"name": "timestamp", "dataType": ["date"], "indexInverted": True, "indexRangeFilters": True},
+        {"name": "involvedPeople", "dataType": ["string[]"], "indexInverted": True},
+        {"name": "referencedArtifacts", "dataType": ["string[]"], "indexInverted": True},
+        {"name": "confidence", "dataType": ["number"], "indexInverted": True, "indexRangeFilters": True},
+    ]
+
     return {
         "class": "MemoryObject",
-        "properties": [
-            {"name": "meeting_id", "dataType": ["string"]},
-            {"name": "type", "dataType": ["string"]},
-            {"name": "content", "dataType": ["text"]},
-            {"name": "confidence", "dataType": ["number"]},
-        ],
+        "description": "Core memory unit from meetings",
         "vectorizer": "text2vec-openai",
+        "moduleConfig": _EMBEDDING_MODULE,
+        "properties": properties,
+        "invertedIndexConfig": {
+            "indexTimestamps": True,
+            "indexNullState": True,
+            "indexPropertyLength": True,
+        },
+        "replicationConfig": {"factor": 3},
     }
 
 
 def meeting_schema() -> Dict[str, Any]:
+    properties: List[Dict[str, Any]] = [
+        {"name": "title", "dataType": ["string"], "indexInverted": True, "indexSearchable": True},
+        {"name": "date", "dataType": ["date"], "indexInverted": True, "indexRangeFilters": True},
+        {"name": "participants", "dataType": ["string[]"], "indexInverted": True},
+        {"name": "duration", "dataType": ["int"]},
+        {"name": "project", "dataType": ["string"], "indexInverted": True, "indexFilterable": True},
+        {"name": "transcriptUrl", "dataType": ["string"]},
+        {"name": "summary", "dataType": ["text"], "description": "AI-generated meeting summary"},
+    ]
+
     return {
         "class": "Meeting",
-        "properties": [
-            {"name": "subject", "dataType": ["text"]},
-            {"name": "date", "dataType": ["date"]},
-        ],
+        "description": "Meeting metadata and summary",
         "vectorizer": "text2vec-openai",
+        "moduleConfig": _EMBEDDING_MODULE,
+        "properties": properties,
     }

--- a/meeting-intelligence/src/storage/neo4j_client.py
+++ b/meeting-intelligence/src/storage/neo4j_client.py
@@ -1,11 +1,39 @@
 from __future__ import annotations
 
-from neo4j import GraphDatabase
+from typing import Any, Dict, Iterable, Optional
+
+from neo4j import GraphDatabase, Driver
+from neo4j.exceptions import Neo4jError
 
 
 class Neo4jClient:
+    """Simple wrapper around the Neo4j driver."""
+
     def __init__(self, uri: str, user: str, password: str) -> None:
-        self.driver = GraphDatabase.driver(uri, auth=(user, password))
+        self.driver: Driver = GraphDatabase.driver(uri, auth=(user, password))
 
     def close(self) -> None:
         self.driver.close()
+
+    def execute(self, cypher: str, parameters: Optional[Dict[str, Any]] = None) -> Iterable[Dict[str, Any]]:
+        """Execute a Cypher query and return results."""
+        with self.driver.session() as session:
+            try:
+                result = session.run(cypher, parameters or {})
+                return list(result.data())
+            except Neo4jError as exc:
+                raise RuntimeError(f"Neo4j query error: {exc}") from exc
+
+    def create_node(self, cypher: str, parameters: Dict[str, Any]) -> None:
+        self.execute(cypher, parameters)
+
+    def create_relationship(self, cypher: str, parameters: Dict[str, Any]) -> None:
+        self.execute(cypher, parameters)
+
+    def traverse(self, start_id: str, relationship_types: list[str], max_depth: int = 3) -> Iterable[Dict[str, Any]]:
+        match_rel = "|".join(f":{r}" for r in relationship_types)
+        cypher = (
+            f"MATCH (n {{meetingId: $start_id}})-[r{match_rel}*1..{max_depth}]->(m) "
+            f"RETURN m, r"
+        )
+        return self.execute(cypher, {"start_id": start_id})

--- a/meeting-intelligence/src/storage/weaviate_client.py
+++ b/meeting-intelligence/src/storage/weaviate_client.py
@@ -1,13 +1,56 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import weaviate
+from weaviate import Client
+from weaviate.exceptions import WeaviateBaseError
 
 
 class WeaviateClient:
-    def __init__(self, url: str) -> None:
-        self.client = weaviate.Client(url)
+    """Wrapper around the Weaviate client with helper operations."""
+
+    def __init__(self, url: str, api_key: Optional[str] = None) -> None:
+        headers = {"X-OpenAI-Api-Key": api_key} if api_key else None
+        self.client = Client(url=url, additional_headers=headers)
 
     def create_schema(self, schema: Dict[str, Any]) -> None:
-        self.client.schema.create_class(schema)
+        try:
+            self.client.schema.create_class(schema)
+        except WeaviateBaseError as exc:
+            if "already exists" not in str(exc):
+                raise
+
+    def store_object(self, class_name: str, data: Dict[str, Any]) -> str:
+        """Store a single object and return its id."""
+
+        try:
+            obj = self.client.data_object.create(data, class_name)
+            return obj.get("id", "")
+        except WeaviateBaseError as exc:
+            raise RuntimeError(f"Weaviate store error: {exc}") from exc
+
+    def batch_store(self, class_name: str, objects: List[Dict[str, Any]]) -> None:
+        """Store objects in batch."""
+
+        with self.client.batch as batch:
+            for obj in objects:
+                batch.add_data_object(obj, class_name)
+
+    def hybrid_search(self, class_name: str, query: str, limit: int = 10) -> Dict[str, Any]:
+        """Perform hybrid search with vector and keyword."""
+
+        return (
+            self.client.query.get(class_name, ["*"])
+            .with_hybrid(query, alpha=0.5)
+            .with_limit(limit)
+            .do()
+        )
+
+    def semantic_search(self, class_name: str, query: str, limit: int = 10) -> Dict[str, Any]:
+        return (
+            self.client.query.get(class_name, ["*"])
+            .with_near_text({"concepts": [query]})
+            .with_limit(limit)
+            .do()
+        )


### PR DESCRIPTION
## Summary
- expand Pydantic memory models and schemas
- add MeetingData email parser
- implement basic LLM-backed MemoryFactory
- create Weaviate and Neo4j client helpers
- expand configuration management

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f472e5148322b4d007f1ffd6620e