### PR TITLE
Implement enhanced Settings with env config

### DIFF
--- a/meeting-intelligence/README.md
+++ b/meeting-intelligence/README.md
@@ -3,3 +3,27 @@
 This project implements a Python-based Meeting Intelligence System. It processes meeting emails, extracts structured "memory" objects and stores them in vector and graph databases. The system is designed to run on Python **3.11+** and uses type hints throughout the codebase.
 
 The project is currently in its initialization phase. Future phases will add advanced extraction, storage and query capabilities based on the `meeting-intelligence-requirements.md` specifications.
+
+## Configuration
+
+Runtime configuration is managed via a `.env` file loaded by `Settings`. The following variables are supported (all optional with sane defaults):
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | API key for OpenAI models | `''` |
+| `OPENROUTER_API_KEY` | API key for OpenRouter models | `''` |
+| `NEO4J_URI` | Neo4j connection string | `bolt://neo4j:7687` |
+| `NEO4J_USER` | Neo4j username | `neo4j` |
+| `NEO4J_PASSWORD` | Neo4j password | `''` |
+| `REDIS_HOST` | Redis host | `redis` |
+| `REDIS_PORT` | Redis port | `6379` |
+| `WEAVIATE_HOST` | Weaviate host | `weaviate` |
+| `WEAVIATE_PORT` | Weaviate port | `8080` |
+| `OPENAI_MODEL` | OpenAI model name | `gpt-4o` |
+| `OPENROUTER_MODEL` | OpenRouter model name | `google/gemini-2.5-flash-preview-05-20` |
+| `BATCH_SIZE` | Batch size for processing jobs | `8` |
+| `PROCESSING_TIMEOUT` | Timeout (ms) for processing operations | `300000` |
+| `ENABLE_VECTOR_STORE` | Toggle usage of the vector store | `true` |
+| `ENABLE_GRAPH_STORE` | Toggle usage of the graph store | `true` |
+
+Create a `.env` file based on `.env.example` and adjust values as needed.

--- a/meeting-intelligence/src/config/settings.py
+++ b/meeting-intelligence/src/config/settings.py
@@ -1,11 +1,35 @@
 from __future__ import annotations
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, Field
 
 
 class Settings(BaseSettings):
-    openai_apikey: str
-    neo4j_password: str
+    """Application configuration loaded from environment variables."""
+
+    # API keys
+    openai_api_key: str = Field('', env="OPENAI_API_KEY")
+    openrouter_api_key: str = Field('', env="OPENROUTER_API_KEY")
+
+    # Database connections
+    neo4j_uri: str = Field('bolt://neo4j:7687', env="NEO4J_URI")
+    neo4j_user: str = Field('neo4j', env="NEO4J_USER")
+    neo4j_password: str = Field('', env="NEO4J_PASSWORD")
+    redis_host: str = Field('redis', env="REDIS_HOST")
+    redis_port: int = Field(6379, env="REDIS_PORT")
+    weaviate_host: str = Field('weaviate', env="WEAVIATE_HOST")
+    weaviate_port: int = Field(8080, env="WEAVIATE_PORT")
+
+    # Model selection
+    openai_model: str = Field('gpt-4o', env="OPENAI_MODEL")
+    openrouter_model: str = Field('google/gemini-2.5-flash-preview-05-20', env="OPENROUTER_MODEL")
+
+    # Processing limits
+    batch_size: int = Field(8, env="BATCH_SIZE")
+    processing_timeout: int = Field(300_000, env="PROCESSING_TIMEOUT")
+
+    # Feature flags
+    enable_vector_store: bool = Field(True, env="ENABLE_VECTOR_STORE")
+    enable_graph_store: bool = Field(True, env="ENABLE_GRAPH_STORE")
 
     class Config:
         env_file = '.env'


### PR DESCRIPTION
## Summary
- expand the Pydantic Settings class to cover API keys, DB URLs, model options, limits and feature flags
- load configuration from `.env` with sensible defaults
- document the available environment variables in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571d29e28483229c9700af297c8fb3