### PR TITLE
Add task update agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Codex Task Update Agent Guide
+
+This repository includes a task tracker (`CLAUDE_TASK_TRACKER.md`) and a detailed plan (`DETAILED_TASK_PLAN.md`). Codex agents should keep these files in sync with the code base.
+
+## Using the Task Agent
+
+A helper script `meeting-intelligence/src/task_agent.py` automates basic updates to the tracker.
+
+### Commands
+
+- `python meeting-intelligence/src/task_agent.py list`
+  - Display all tasks and their status.
+- `python meeting-intelligence/src/task_agent.py complete "<keyword>"`
+  - Mark the first pending task containing `<keyword>` as complete.
+- `python meeting-intelligence/src/task_agent.py add "<Section>" "<Task description>"`
+  - Add a new task under the specified section heading in the tracker.
+
+## Workflow
+
+1. After implementing a feature or fixing a bug, update `CLAUDE_TASK_TRACKER.md` using the task agent.
+2. If new work arises, add it to the tracker and summarize it in `DETAILED_TASK_PLAN.md`.
+3. Commit code and documentation changes together with a clear message referencing the tasks.
+4. Run `pytest` before submitting a pull request. If dependencies are missing, note this in the PR.

--- a/meeting-intelligence/src/task_agent.py
+++ b/meeting-intelligence/src/task_agent.py
@@ -1,0 +1,79 @@
+import argparse
+import re
+from pathlib import Path
+from typing import List
+
+TRACKER_PATH = Path(__file__).resolve().parents[2] / "CLAUDE_TASK_TRACKER.md"
+
+TASK_PATTERN = re.compile(r"^- \[( |x)\] (.+)")
+
+
+def _read_tracker() -> List[str]:
+    return TRACKER_PATH.read_text().splitlines(True)
+
+
+def list_tasks() -> None:
+    for line in _read_tracker():
+        m = TASK_PATTERN.match(line)
+        if m:
+            status = "done" if m.group(1) == "x" else "pending"
+            print(f"{status:7} - {m.group(2)}")
+
+
+def mark_complete(keyword: str) -> None:
+    lines = _read_tracker()
+    new_lines = []
+    keyword_lower = keyword.lower()
+    updated = False
+    for line in lines:
+        m = TASK_PATTERN.match(line)
+        if m and keyword_lower in m.group(2).lower() and m.group(1) != "x":
+            line = line.replace("[ ]", "[x]", 1)
+            updated = True
+        new_lines.append(line)
+    TRACKER_PATH.write_text("".join(new_lines))
+    if updated:
+        print(f"Marked tasks containing '{keyword}' as complete.")
+    else:
+        print(f"No pending task matched '{keyword}'.")
+
+
+def add_task(section: str, task: str) -> None:
+    lines = _read_tracker()
+    section_header = f"## {section}"
+    for idx, line in enumerate(lines):
+        if line.strip() == section_header:
+            lines.insert(idx + 1, f"- [ ] {task}\n")
+            TRACKER_PATH.write_text("".join(lines))
+            print(f"Added task under '{section}'.")
+            return
+    raise ValueError(f"Section '{section}' not found in tracker")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update CLAUDE_TASK_TRACKER.md")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sub.add_parser("list", help="List all tasks")
+
+    cpl = sub.add_parser("complete", help="Mark task as complete")
+    cpl.add_argument("keyword", help="Keyword identifying the task")
+
+    add = sub.add_parser("add", help="Add a new task")
+    add.add_argument("section", help="Tracker section name")
+    add.add_argument("task", help="Task description")
+
+    args = parser.parse_args()
+
+    if args.cmd == "list":
+        list_tasks()
+    elif args.cmd == "complete":
+        mark_complete(args.keyword)
+    elif args.cmd == "add":
+        add_task(args.section, args.task)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `AGENTS.md` describing how Codex agents should update tasks
- implement `task_agent.py` to list, complete, and add tracker items

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_685726b9b6288322af5e0b24b51e0bd6