### PR TITLE
Add unresolved thread tracking feature

### DIFF
--- a/CLAUDE_TASK_TRACKER.md
+++ b/CLAUDE_TASK_TRACKER.md
@@ -19,6 +19,7 @@ This tracker outlines the tasks from [claude-code-guide.md](./claude-code-guide.
 - [ ] **Task 8: Advanced Memory Extraction**
 - [ ] **Task 9: Query Orchestrator Foundation**
 - [ ] **Task 10: Context Builder v1**
+- [ ] **Task 10b: Unresolved Thread Tracker**
 
 ## Phase 3: Advanced Capabilities (Weeks 9-12)
 - [ ] **Task 11: Iterative Query Refinement**

--- a/DETAILED_TASK_PLAN.md
+++ b/DETAILED_TASK_PLAN.md
@@ -131,6 +131,27 @@ class TemporalDateCalculator:
 4. Test with various reference dates
 5. Integrate with TemporalExtractor
 
+### Phase 2.4: Unresolved Thread Tracking
+
+**File**: `/meeting-intelligence/src/analysis/unresolved_thread_tracker.py`
+
+```python
+class UnresolvedThreadTracker:
+    def __init__(self, neo4j: Neo4jClient) -> None:
+        self.neo4j_driver = neo4j.driver
+
+    def track_unresolved_threads(self, chunks: List[TemporalMemoryChunk]) -> Dict[str, List[Dict]]:
+        """Identify unanswered questions and unresolved issues"""
+        # Implementation described in requirements
+```
+
+**Tasks**:
+1. Implement `_find_answer_for_question` to match answers with questions
+2. Implement `_check_future_meetings` using Neo4j queries
+3. Aggregate unresolved items by days outstanding
+4. Integrate tracker results into reports
+5. Add tests covering unanswered question detection
+
 ### Phase 3.1: DualStorageManager (CRITICAL - v3 Core)
 
 **File**: `/meeting-intelligence/src/storage/dual_storage_manager.py`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -482,6 +482,20 @@ class ContextScorer:
         return sum(scores[k] * self.weights[k] for k in scores)
 ```
 
+#### 2.3.4 Unresolved Thread Tracking
+
+Track open questions and unresolved issues across meetings so that action items do not get lost.
+
+```python
+class UnresolvedThreadTracker:
+    def __init__(self, neo4j_driver):
+        self.neo4j_driver = neo4j_driver
+
+    def track_unresolved_threads(self, chunks: List[TemporalMemoryChunk]) -> Dict[str, List[Dict]]:
+        """Identify questions/issues that were never resolved"""
+        # Implementation inspects chunks and checks Neo4j for answers
+```
+
 ### 2.4 Context Assembly & Response Generation
 
 #### 2.4.1 Final Context Structure
@@ -809,6 +823,7 @@ COST_OPTIMIZATION = {
 - Graph relationship building
 - Query orchestration engine v1
 - Iterative context building
+- Unresolved thread tracking across meetings
 
 **Success Criteria:**
 - Extract 8-15 quality memories per meeting

--- a/meeting-intelligence/meeting-intelligence-requirements.md
+++ b/meeting-intelligence/meeting-intelligence-requirements.md
@@ -482,6 +482,20 @@ class ContextScorer:
         return sum(scores[k] * self.weights[k] for k in scores)
 ```
 
+#### 2.3.4 Unresolved Thread Tracking
+
+Track open questions and unresolved issues across meetings so important items are not forgotten.
+
+```python
+class UnresolvedThreadTracker:
+    def __init__(self, neo4j_driver):
+        self.neo4j_driver = neo4j_driver
+
+    def track_unresolved_threads(self, chunks: List[TemporalMemoryChunk]) -> Dict[str, List[Dict]]:
+        """Identify questions/issues that were never resolved"""
+        # Implementation inspects chunks and checks Neo4j for answers
+```
+
 ### 2.4 Context Assembly & Response Generation
 
 #### 2.4.1 Final Context Structure
@@ -809,6 +823,7 @@ COST_OPTIMIZATION = {
 - Graph relationship building
 - Query orchestration engine v1
 - Iterative context building
+- Unresolved thread tracking across meetings
 
 **Success Criteria:**
 - Extract 8-15 quality memories per meeting

--- a/meeting-intelligence/src/analysis/unresolved_thread_tracker.py
+++ b/meeting-intelligence/src/analysis/unresolved_thread_tracker.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from ..models.temporal_memory import TemporalMemoryChunk
+from ..storage.neo4j_client import Neo4jClient
+
+
+class UnresolvedThreadTracker:
+    """Utility for tracking unanswered questions and unresolved issues."""
+
+    def __init__(self, neo4j: Neo4jClient) -> None:
+        self.neo4j_driver = neo4j.driver
+
+    def _find_answer_for_question(
+        self, question: TemporalMemoryChunk, answers: List[TemporalMemoryChunk]
+    ) -> bool:
+        """Check if any answer addresses the question."""
+        for ans in answers:
+            if ans.timestamp >= question.timestamp and question.speaker in ans.addressed_to:
+                return True
+        return False
+
+    def _check_future_meetings(self, question: TemporalMemoryChunk) -> bool:
+        """Query Neo4j for answers in later meetings."""
+        query = (
+            "MATCH (q:Chunk {chunkId: $cid})-[:SPOKEN_IN]->(m:Meeting)<-[:SPOKEN_IN]-(a:Chunk) "
+            "WHERE a.interactionType = 'answer' AND a.timestamp > q.timestamp "
+            "RETURN a LIMIT 1"
+        )
+        with self.neo4j_driver.session() as session:
+            result = session.run(query, cid=question.chunk_id)
+            return result.single() is not None
+
+    def track_unresolved_threads(
+        self, chunks: List[TemporalMemoryChunk]
+    ) -> Dict[str, List[Dict[str, object]]]:
+        """Identify questions or issues that remain unresolved."""
+
+        threads = {
+            "unanswered_questions": [],
+            "unassigned_tasks": [],
+            "unresolved_issues": [],
+        }
+
+        questions = [c for c in chunks if c.interaction_type == "question"]
+        answers = [c for c in chunks if c.interaction_type == "answer"]
+
+        for question in questions:
+            has_answer = self._find_answer_for_question(question, answers)
+            if not has_answer:
+                if not self._check_future_meetings(question):
+                    threads["unanswered_questions"].append(
+                        {
+                            "question": question.content,
+                            "asked_by": question.speaker,
+                            "asked_in": question.meeting_id,
+                            "importance": question.importance_score,
+                            "days_unresolved": (datetime.now() - question.timestamp).days,
+                        }
+                    )
+
+        # TODO: track unassigned tasks and unresolved issues from chunks
+        # This requires additional classification logic not yet implemented.
+
+        # Identify stale questions from Neo4j older than 7 days with no answers
+        with self.neo4j_driver.session() as session:
+            query = (
+                "MATCH (q:Chunk {interactionType: 'question'}) "
+                "WHERE NOT EXISTS { MATCH (q)-[:ANSWERED_BY]->(:Chunk) } "
+                "AND q.timestamp < datetime() - duration('P7D') "
+                "RETURN q ORDER BY q.importance_score DESC"
+            )
+            results = session.run(query)
+            for record in results:
+                q = record["q"]
+                threads["unanswered_questions"].append(
+                    {
+                        "question": q["content"],
+                        "asked_by": q.get("speaker", "unknown"),
+                        "asked_in": q.get("meetingId", ""),
+                        "importance": q.get("importanceScore", 5.0),
+                        "days_unresolved": (
+                            datetime.now()
+                            - datetime.fromisoformat(q["timestamp"])
+                        ).days,
+                    }
+                )
+
+        return threads

--- a/meeting-intelligence/src/storage/dual_storage_manager.py
+++ b/meeting-intelligence/src/storage/dual_storage_manager.py
@@ -95,7 +95,10 @@ class DualStorageManager:
 
     @staticmethod
     def _create_chunk_tx(
-        tx, chunk: TemporalMemoryChunk, meeting_metadata: Dict[str, Any]
+        tx,
+        chunk: TemporalMemoryChunk,
+        meeting_metadata: Dict[str, Any],
+    ) -> None:
         query = (
             "MERGE (c:Chunk {chunkId: $cid}) "
             "SET c.content=$content, c.speaker=$speaker, c.timestamp=datetime($ts), "
@@ -123,4 +126,4 @@ class DualStorageManager:
             importance_score=chunk.importance_score,
             mid=meeting_metadata["meeting_id"],
         )
-        )
+

--- a/requirements.md
+++ b/requirements.md
@@ -482,6 +482,21 @@ class ContextScorer:
         return sum(scores[k] * self.weights[k] for k in scores)
 ```
 
+#### 2.3.4 Unresolved Thread Tracking
+
+Track open questions and unresolved issues across meetings so nothing falls
+through the cracks.
+
+```python
+class UnresolvedThreadTracker:
+    def __init__(self, neo4j_driver):
+        self.neo4j_driver = neo4j_driver
+
+    def track_unresolved_threads(self, chunks: List[TemporalMemoryChunk]) -> Dict[str, List[Dict]]:
+        """Identify questions/issues that were never resolved"""
+        # Implementation inspects chunks and checks Neo4j for answers
+```
+
 ### 2.4 Context Assembly & Response Generation
 
 #### 2.4.1 Final Context Structure
@@ -809,6 +824,7 @@ COST_OPTIMIZATION = {
 - Graph relationship building
 - Query orchestration engine v1
 - Iterative context building
+- Unresolved thread tracking across meetings
 
 **Success Criteria:**
 - Extract 8-15 quality memories per meeting


### PR DESCRIPTION
## Summary
- add an `UnresolvedThreadTracker` utility for unanswered question detection
- update requirements docs with the new feature and roadmap bullet
- update detailed task plan with phase for unresolved thread tracking
- mark new task in CLAUDE task tracker
- fix DualStorageManager syntax

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685728c5b6dc8322bc96570f73704a76